### PR TITLE
Added sslserver package and ssl settings

### DIFF
--- a/mesa_gui/mesa_gui/settings.py
+++ b/mesa_gui/mesa_gui/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'mesa',
+    'sslserver'
 ]
 
 MIDDLEWARE = [
@@ -129,3 +130,7 @@ STATICFILES_DIRS = [
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+SECURE_SSL_REDIRECT = True
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.11"
 django = "^4.2.4"
 pytz = "^2023.3"
 psutil = "^5.9.5"
-
+django-sslserver = "^0.22"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Added ssl support for the MESA GUI. This involved adding the django-sslserver package to the python dependencies in pyproject.toml, and some additional configurations to settings.py.
