### PR TITLE
Update for report without jobs

### DIFF
--- a/mesa_gui/mesa/views.py
+++ b/mesa_gui/mesa/views.py
@@ -103,25 +103,16 @@ def job_generate_report(request):
         settings = Settings.get_settings()
         zip_file_path = f"/root/.mesa/projects/output/{settings.project_name}/customer_deliverable/{settings.customer_initials}-Customer-Report.zip"
         
-        if os.path.exists(zip_file_path) and os.path.getsize(zip_file_path) > 0:
-            file = open(zip_file_path, 'rb')
-            response = FileResponse(file, as_attachment=True, filename=smart_str(os.path.basename(zip_file_path)))
-            return response
-        else:
-            for job in jobs:
-                if job.status != MesaJob.MESA_JOB_STATUS_COMPLETE and job.name != MesaJob.MESA_JOB_ALL_CHECKS_NAME:
-                    return JsonResponse({'code': '409', 'status': f'{job.name} is not complete'})
-            
-            # Run the report generator function of MESA-Toolkit
-            process = subprocess.Popen(f"MESA-Toolkit --project-name {settings.project_name} --customer-name '{settings.customer_name}' --customer-initials {settings.customer_initials} -o report_generator", shell=True, cwd=MesaJob.get_job_directory())
-            process.wait() # Wait for the command to complete
+        # Run the report generator function of MESA-Toolkit
+        process = subprocess.Popen(f"MESA-Toolkit --project-name {settings.project_name} --customer-name '{settings.customer_name}' --customer-initials {settings.customer_initials} -o report_generator", shell=True, cwd=MesaJob.get_job_directory())
+        process.wait() # Wait for the command to complete
 
-            # Now proceed to download the file
-            file = open(zip_file_path, 'rb')
-            response = FileResponse(file, as_attachment=True, filename=smart_str(os.path.basename(zip_file_path)))
-            # This is a temporary fix until the Download Report button has been updated
-            os.system("rm -rf /root/.mesa/projects/output")
-            return response
+        # Now proceed to download the file
+        file = open(zip_file_path, 'rb')
+        response = FileResponse(file, as_attachment=True, filename=smart_str(os.path.basename(zip_file_path)))
+        # This is a temporary fix until the Download Report button has been updated
+        os.system("rm -rf /root/.mesa/projects/output")
+        return response
     else:
         return JsonResponse({"status": "404"})
 


### PR DESCRIPTION
# <!-- Update for report without jobs--> #

## 🗣 Description ##

Removed lines 106 - 113 
Shift lines 115 - 124 back one indentation block to be in line with line 104. 
 This will allow for the new code in mesa-toolkit to run

## 💭 Motivation and context ##

Report generator only works if all scans are completed
Used a check system and if scan was not completed it will return a 0

## 🧪 Testing ##

Download report with no jobs complete
Download report with 1-4 jobs complete
Download report with all jobs complete
Kali virtual machine running multiple web browser tabs 
