### PR TITLE
Added STATIC_ROOT variable; removed STATICFILES_DIRS

### DIFF
--- a/mesa_gui/mesa_gui/settings.py
+++ b/mesa_gui/mesa_gui/settings.py
@@ -16,12 +16,6 @@ from pathlib import Path
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-def find_static_root():
-    for root, dirs, files in os.walk(BASE_DIR):
-        if "mesa_gui" in root and "static_files" in dirs:
-            return os.path.join(root, "static_files")
-    return None
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
@@ -126,9 +120,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
-STATIC_ROOT = find_static_root()
-if not STATIC_ROOT:
-    raise Exception("Error: 'static_files' directory not found")
+STATIC_ROOT = os.path.join(BASE_DIR, 'static_files')
 STATIC_URL = 'static/'
 
 # Default primary key field type

--- a/mesa_gui/mesa_gui/settings.py
+++ b/mesa_gui/mesa_gui/settings.py
@@ -121,10 +121,8 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
+STATIC_ROOT = "/opt/src/github.com/cisagov/mesa-gui/mesa_gui/static_files/"
 STATIC_URL = 'static/'
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'static_files'),
-]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field

--- a/mesa_gui/mesa_gui/settings.py
+++ b/mesa_gui/mesa_gui/settings.py
@@ -16,6 +16,11 @@ from pathlib import Path
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+def find_static_root():
+    for root, dirs, files in os.walk(BASE_DIR):
+        if "mesa_gui" in root and "static_files" in dirs:
+            return os.path.join(root, "static_files")
+    return None
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
@@ -121,7 +126,9 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
-STATIC_ROOT = "/opt/src/github.com/cisagov/mesa-gui/mesa_gui/static_files/"
+STATIC_ROOT = find_static_root()
+if not STATIC_ROOT:
+    raise Exception("Error: 'static_files' directory not found")
 STATIC_URL = 'static/'
 
 # Default primary key field type


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The /admin/ page of the MESA web application wasn't rendering properly. Adding a STATIC_ROOT variable to the settings.py file and running `python manage.py collectstatic` fixes this issue.

## 🧪 Testing ##

On a working mesa-ops VM, I added a STATIC_ROOT variable to the settings.py file and ran `python manage.py collectstatic`, which fixed the page rendering issue.

- [x] Create the mesa-ops VM using the packer repo: https://github.com/cisagov/mesa-packer
- [x] In the file `/opt/src/github.com/cisagov/mesa-gui/mesa_gui/mesa_gui/settings.py`, remove the `STATICFILES_DIRS` variable
- [x] In the file `/opt/src/github.com/cisagov/mesa-gui/mesa_gui/mesa_gui/settings.py`, add the following: `STATIC_ROOT = "/opt/src/github.com/cisagov/mesa-gui/mesa_gui/static_files/"`
- [x] In the MESA-venv virtual environment, run `python3 manage.py collectstatic`
- [x] Restart nginx
- [x] Restart mesa.service
- [x] Check to ensure MESA web application, to include /admin/, is rendered properly

## 📷 Screenshots (if appropriate) ##

![Screenshot 2024-09-27 at 12 16 50 PM](https://github.com/user-attachments/assets/d8906d13-689b-4700-93a6-7431146623ff)

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

